### PR TITLE
Add default training logger

### DIFF
--- a/dist/anny.js
+++ b/dist/anny.js
@@ -596,7 +596,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param {object[]} data - Array of objects in the form
 	 * `{input: [], output: []}`.
 	 * @param {function} [callback] - Called with the current error every
-	 *   `callbackFrequency`.
+	 *   `frequency`.
 	 * @param {number} [frequency] - How many iterations to let pass between
 	 *   logging the current error.
 	 */
@@ -608,6 +608,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var epochs = 50000;
 	  var errorThreshold = 0.001;
 	  var callbackFrequency = frequency || _.max([1, _.floor(epochs / 20)]);
+
+	  var defaultCallback = function(err, epoch) {
+	    console.log('epcoh', epoch, 'error:', err);
+	  };
 
 	  _.each(_.range(epochs), function(index) {
 	    var n = index + 1;
@@ -627,8 +631,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }, this));
 
 	    // callback with results periodically
-	    if (_.isFunction(callback) && (n === 1 || n % callbackFrequency === 0)) {
-	      callback(avgError, n);
+	    if (n === 1 || n % callbackFrequency === 0) {
+	      (callback || defaultCallback)(avgError, n);
 	    }
 
 	    // success / fail

--- a/lib/Network.js
+++ b/lib/Network.js
@@ -92,7 +92,7 @@ Network.prototype.correct = function(output) {
  * @param {object[]} data - Array of objects in the form
  * `{input: [], output: []}`.
  * @param {function} [callback] - Called with the current error every
- *   `callbackFrequency`.
+ *   `frequency`.
  * @param {number} [frequency] - How many iterations to let pass between
  *   logging the current error.
  */
@@ -104,6 +104,10 @@ Network.prototype.train = function(data, callback, frequency) {
   var epochs = 50000;
   var errorThreshold = 0.001;
   var callbackFrequency = frequency || _.max([1, _.floor(epochs / 20)]);
+
+  var defaultCallback = function(err, epoch) {
+    console.log('epcoh', epoch, 'error:', err);
+  };
 
   _.each(_.range(epochs), function(index) {
     var n = index + 1;
@@ -123,8 +127,8 @@ Network.prototype.train = function(data, callback, frequency) {
     }, this));
 
     // callback with results periodically
-    if (_.isFunction(callback) && (n === 1 || n % callbackFrequency === 0)) {
-      callback(avgError, n);
+    if (n === 1 || n % callbackFrequency === 0) {
+      (callback || defaultCallback)(avgError, n);
     }
 
     // success / fail


### PR DESCRIPTION
Network.train() calls a callback after `frequency` number of training epochs.  This PR adds a simple default callback that logs the current epoch and error.