### PR TITLE
Batch training

### DIFF
--- a/app/src/components/anny/anny-factory.js
+++ b/app/src/components/anny/anny-factory.js
@@ -24,7 +24,7 @@ function AnnyFactory($rootScope) {
   };
 
   factory.train = function(trainingSet, callback, frequency) {
-    factory.network.train(trainingSet, callback, frequency);
+    factory.network.trainBatch(trainingSet, callback, frequency);
 
     var results = ['Predictions after training:'];
 

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -57,10 +57,24 @@ class Layer {
    * Layers.
    * @param {number[]} [outputs] - Map of target output values for each Neuron.
    */
-  train(outputs) {
+  setDelta(outputs) {
     _.each(this.neurons, (neuron, i) => {
-      neuron.train(outputs ? outputs[i] : undefined);
+      neuron.setDelta(outputs ? outputs[i] : undefined);
     });
+  }
+
+  /**
+   * Train the Neurons in this layer.  If target `outputs` are specified, the
+   * Neurons will learn to output these values.  This is only useful for output
+   * Layers.
+   * @param {number[]} [outputs] - Map of target output values for each Neuron.
+   */
+  learn() {
+    _.invoke(this.neurons, 'learn');
+  }
+
+  zeroDelta() {
+    _.invoke(this.neurons, 'zeroDelta');
   }
 }
 

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -42,7 +42,6 @@ class Neuron {
     // learning
     this.error = 0;
     this.delta = 0;
-    this.cycles = 1;
     this.learningRate = INITIALIZE.learningRate();
   }
 
@@ -53,8 +52,6 @@ class Neuron {
    * @param {number} [targetOutput] - Manually set the target output.error.
    */
   setDelta(targetOutput) {
-    this.cycles++;
-
     let inputDerivative = this.activation.prime(this.input);
 
     if (!_.isUndefined(targetOutput)) {
@@ -92,17 +89,15 @@ class Neuron {
   learn() {
     // adjust weights
     _.each(this.outgoing, connection => {
-      connection.weight -=
-        connection.gradient * this.learningRate / this.cycles;
+      connection.weight -= connection.gradient * this.learningRate;
+      // zero the gradient now that we've used it for learning
+      // it will be accumulated on the next setDelta call(s)
       connection.gradient = 0;
     });
   }
 
   zeroDelta() {
     this.delta = 0;
-    this.cycles = 0;
-    _.each(this.outgoing, connection => {
-    });
   }
 
   /**


### PR DESCRIPTION
So far, batch training is 2 orders of magnitude slower at converging than online training.  This article, and its benchmark image, may shed more light: https://visualstudiomagazine.com/Articles/2014/08/01/Batch-Training.aspx?Page=2

Also, batch training requires storing more data (delta and gradient accumulators).  Lastly, since training is now split from delta and gradient calculation, this means we have to loop through the entire network 2 additional times every epoch compared to online training.  Once to reset deltas/gradients, another to accumulate deltas/gradients, and again to update weights based on accumulated deltas.  Constrast this with online learning, there is a single train method that can do all three of these processes in one loop.

With the same training rate of 0.3, Anny takes on average 420 epochs to train an OR gate where the online method takes 250 average epochs.

An error is suspected as the other gates do not converge.  Also, the larger the network, the greater chance of not converging even on an OR gate.  This is the opposite case as the online method, where slightly larger nets trained better on all gates compared to the minimum required net size.