### PR TITLE
Remove Network.train() console.logs in favor of callbacks

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -2,7 +2,7 @@ instrumentation:
   excludes: [app, dist, docs, gulp, test]
 check:
   global:
-    statements: 96
-    branches: 92
+    statements: 99
+    branches: 97
     functions: 98
-    lines: 93
+    lines: 95

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ or try the [demo](http://dev-coop.github.io/anny).
 Train a multilayer perceptron to approximate an OR logic gate:
 
 ```js
-var network = new anny.Network([2, 1]);
-network.train(anny.DATA.ANDGate);
+const network = new anny.Network([2, 1])
+network.train(anny.DATA.ANDGate)
 
-network.activate([0, 0]); // => 0.000836743108
-network.activate([0, 1]); // => 0.998253857294
+network.activate([0, 0]) // => 0.000836743108
+network.activate([0, 1]) // => 0.998253857294
 ```
 
 ## Why Anny?

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:watch": "watch 'npm run lint --silent' -d -u",
     "test:watch": "babel-node $(npm bin)/isparta cover _mocha -- -w",
+    "babel-node": "babel-node",
+    "playground": "nodemon --exec npm run babel-node -- playground.js",
     "postinstall": "bower install",
     "clean": "while read line; do rm -rf $line; done < .gitignore"
   },

--- a/playground.js
+++ b/playground.js
@@ -1,0 +1,19 @@
+import Network from './src/Network'
+import Data from './src/Data'
+
+const network = new Network([2, 5, 1])
+
+network.train(Data.ORGate, {
+  frequency: 1,
+  onSuccess: (error, epoch) => {
+    console.log(`Successfully trained to ${error} error after ${epoch} epochs`)
+  },
+  onFail: (error, epoch) => {
+    console.log(`Fail to train, error is ${error} after ${epoch} epochs`)
+  },
+  onUpdate: (error, epoch) => {
+    console.log(`${epoch} ${error}`)
+    // exit training
+    return false
+  },
+})

--- a/playground.js
+++ b/playground.js
@@ -1,19 +1,18 @@
+/* eslint-disable no-console */
 import Network from './src/Network'
 import Data from './src/Data'
 
-const network = new Network([2, 5, 1])
+const network = new Network([4, 5, 3])
 
-network.train(Data.ORGate, {
-  frequency: 1,
+network.train(Data.irisFlower, {
+  frequency: 1000,
   onSuccess: (error, epoch) => {
     console.log(`Successfully trained to ${error} error after ${epoch} epochs`)
   },
   onFail: (error, epoch) => {
     console.log(`Fail to train, error is ${error} after ${epoch} epochs`)
   },
-  onUpdate: (error, epoch) => {
+  onProgress: (error, epoch) => {
     console.log(`${epoch} ${error}`)
-    // exit training
-    return false
   },
 })

--- a/src/Network.js
+++ b/src/Network.js
@@ -151,7 +151,7 @@ class Network {
    * @param {Network~onSuccess} [options.onSuccess] - Called if the Network
    *   `error` falls below the `errorThreshold` during training.
    */
-  train(data, options) {
+  train(data, options = {}) {
     validate.trainingData(this, data)
     // TODO: ensure data is normalized to the range of the activation functions
     const {

--- a/src/Network.js
+++ b/src/Network.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import Layer from './Layer'
 import ERROR from './Error'
+import {type} from './Util'
 import validate from './Validate'
 
 /**
@@ -35,7 +36,7 @@ class Network {
   constructor(layerSizes) {
     if (!_.isArray(layerSizes)) {
       throw new Error(
-        `Network() \`layerSizes\` must be an array, not: ${typeof layerSizes}`
+        `Network() \`layerSizes\` must be an array, not: ${type(layerSizes)}`
       )
     }
 
@@ -45,9 +46,6 @@ class Network {
       )
     }
 
-    const inputSize = layerSizes.shift()
-    const outputSize = layerSizes.pop()
-    const hiddenSizes = layerSizes
     /**
      * The output values of the Neurons in the last layer.  This is identical to
      * the Network's `outputLayer` output.
@@ -70,57 +68,35 @@ class Network {
     this.error = null
 
     /**
-     * The max training iterations.  The Network will stop training after
-     * looping through the training data this number of times.  One full loop
-     * through the training data is counted as one epoch.
-     * @type {number}
-     */
-    this.epochs = 20000
-
-    /**
-     * The target `error` value.  The goal of the Network is to train until the
-     * `error` is below this value.
-     * @type {number}
-     */
-    this.errorThreshold = 0.001
-
-    /**
-     * The first Layer of the Network.  This Layer receives input during
-     * activation.
-     * @type {Layer}
-     */
-    this.inputLayer = new Layer(inputSize)
-
-    /**
-     * An array of the `hiddenLayer`s only.
-     * @type {Layer[]}
-     */
-    this.hiddenLayers = _.map(hiddenSizes, size => new Layer(size))
-
-    /**
-     * The first Layer of the Network.  This Layer receives input during
-     * activation.
-     * @type {Layer}
-     */
-    this.outputLayer = new Layer(outputSize)
-
-    /**
      * An array of all Layers in the Network.  It is a single dimension array
      * containing the `inputLayer`, `hiddenLayers`, and the `outputLayer`.
      * @type {Layer}
      */
-    this.allLayers = _.union(
-      [this.inputLayer],
-      this.hiddenLayers,
-      [this.outputLayer]
-    )
+    this.allLayers = _.map(layerSizes, size => new Layer(size))
+    /**
+     * The first Layer of the Network.  This Layer receives input during
+     * activation.
+     * @type {Layer}
+     */
+    this.inputLayer = _.first(this.allLayers)
+
+    /**
+     * An array of all layers between the `inputLayer` and `outputLayer`.
+     * @type {Layer[]}
+     */
+    this.hiddenLayers = _.slice(this.allLayers, 1, this.allLayers.length - 1)
+
+    /**
+     * The last Layer of the Network.  The output of this Layer is the
+     * "prediction" the Network has made for some given input.
+     * @type {Layer}
+     */
+    this.outputLayer = _.last(this.allLayers)
 
     // connect layers
     _.each(this.allLayers, (layer, i) => {
       const next = this.allLayers[i + 1]
-      if (next) {
-        layer.connect(next)
-      }
+      if (next) layer.connect(next)
     })
   }
 
@@ -158,41 +134,62 @@ class Network {
    * Train the Network to produce the output from the given input.
    * @param {object[]} data - Array of objects in the form
    * `{input: [], output: []}`.
-   * @param {function} [callback] - Called with the current error every
-   *   `frequency`.
-   * @param {number} [frequency] - How many iterations to let pass between
-   *   logging the current error.
+   * @param {{}} [options] Training options.
+   * @param {number} [options.errorThreshold=0.001] The target `error` value.
+   *   The goal of the Network is to train until the `error` is below this
+   *   value.
+   * @param {number} [options.frequency] - How many iterations through the
+   *   training data between calling `options.onProgress`.
+   * @param {number} [options.maxEpochs=20000] The max training iterations.
+   *   The Network will stop training after iterating through the training data
+   *   this number of times.  One full loop through the training data is
+   *   counted as one epoch.
+   * @param {Network~onFail} [options.onFail] - Called if the Network `error`
+   *   does not fall below the `errorThreshold` after `maxEpochs`.
+   * @param {Network~onProgress} [options.onProgress] - Called every
+   *   `frequency` epochs.
+   * @param {Network~onSuccess} [options.onSuccess] - Called if the Network
+   *   `error` falls below the `errorThreshold` during training.
    */
-  train(data, callback, frequency = 100) {
+  train(data, options) {
     validate.trainingData(this, data)
-    // TODO: validation and help on the data.
-    //  ensure it is normalized between -1 and 1
-    //  ensure the input length matches the number of Network inputs
-    //  ensure the output length matches the number of Network outputs
-    let lastEpochError = 0
-    let lastEpochTime = Date.now()
-    let lowestEpochError = Infinity
+    // TODO: ensure data is normalized to the range of the activation functions
+    const {
+      errorThreshold = 0.001,
+      frequency = 100,
+      maxEpochs = 20000,
+      onFail = _.noop,
+      onProgress = _.noop,
+      onSuccess = _.noop,
+      } = options
 
-    const defaultCallback = (err, epoch) => {
-      const isNewLow = err < lowestEpochError
-      const difference = err - lastEpochError
-      const time = Date.now() - lastEpochTime
-      const indicator = difference >= 0 ? '↑' : '↓'
-      console.log(
-        `epoch ${_.padRight(epoch, 5)}`,
-        (isNewLow ? '★' : ' '),
-        `err ${err.toFixed(16)}`,
-        indicator, Math.abs(difference).toFixed(16),
-        (`◷ ${(time / 1000).toFixed(2)}s`)
-      )
-      lastEpochError = err
-      lastEpochTime = Date.now()
-      lowestEpochError = Math.min(err, lowestEpochError)
+    if (!_.isNumber(errorThreshold)) {
+      throw new Error(`train(...) "errorThreshold" must be a number.`)
+    }
+
+    if (!_.isNumber(frequency)) {
+      throw new Error(`train(...) "frequency" must be a number.`)
+    }
+
+    if (!_.isNumber(maxEpochs)) {
+      throw new Error(`train(...) "maxEpochs" must be a number`)
+    }
+
+    if (!_.isFunction(onFail)) {
+      throw new Error(`train(...) "onFail" must be a function.`)
+    }
+
+    if (!_.isFunction(onProgress)) {
+      throw new Error(`train(...) "onProgress" must be a function.`)
+    }
+
+    if (!_.isFunction(onSuccess)) {
+      throw new Error(`train(...) "onSuccess" must be a function.`)
     }
 
     // use an 'each' loop so we can break out of it on success/fail
     // a 'times' loop cannot be broken
-    _.each(_.range(this.epochs), index => {
+    _.each(_.range(maxEpochs), index => {
       const n = index + 1
 
       // loop over the training data summing the error of all samples
@@ -209,25 +206,44 @@ class Network {
         return this.errorFn(sample.output, this.output) / data.length
       }))
 
-      // callback with results periodically
-      if (n === 1 || n % frequency === 0) {
-        (callback || defaultCallback)(this.error, n)
+      // success
+      if (this.error <= errorThreshold) {
+        onSuccess(this.error, n)
+        return false
       }
 
-      // success / fail
-      const error = this.error.toFixed(15)
-      if (this.error <= this.errorThreshold) {
-        console.log(
-          `Successfully trained to an error of ${error} after ${n} epochs.`
-        )
-        return false
-      } else if (n === this.epochs) {
-        console.log(
-          `Failed to train. Error is ${error} after ${n} epochs.`
-        )
-      }
+      // fail
+      if (n === maxEpochs) onFail(this.error, n)
+
+      // call onProgress after the first epoch and every `frequency` thereafter
+      if (n === 1 || n % frequency === 0) return onProgress(this.error, n)
     })
   }
+
+  /**
+   * Called if the Network error falls below the `errorThreshold`.
+   * @callback Network~onSuccess
+   * @param {number} error The Network error value at the time of success.
+   * @param {number} epoch Indicates on which iteration through the training
+   *   data the Network became successful.
+   */
+
+  /**
+   * Called if the Network error is not below the `errorThreshold` after
+   * `maxEpochs` iterations through the training data set.
+   * @callback Network~onFail
+   * @param {number} error The Network error value at the time of success.
+   * @param {number} epoch Indicates on which iteration through the training
+   *   data the Network became successful.
+   */
+
+  /**
+   * Called if the Network error falls below the `errorThreshold`.
+   * @callback Network~onProgress
+   * @param {number} error The Network error value at the time of success.
+   * @param {number} epoch Indicates on which iteration through the training
+   *   data the Network became successful.
+   */
 }
 
 export default Network

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -152,9 +152,7 @@ class Neuron {
    */
   connect(target, weight) {
     // bias Neurons are not allowed to have incoming connections
-    if (target.isBias) {
-      return
-    }
+    if (target.isBias) return
 
     const connection = new Neuron.Connection(this, target, weight)
     this.outgoing.push(connection)

--- a/src/Validate.js
+++ b/src/Validate.js
@@ -10,10 +10,11 @@ import {type} from './Util'
  */
 class ValidationError extends Error {
   constructor(message) {
-    super(message)
+    const msg = [].concat(message).join('')
+    super(msg)
     this.name = 'ValidationError'
-    this.message = [].concat(message).join('')
-    this.stack = (new Error()).stack
+    this.message = msg
+    Error.captureStackTrace(this, 'ValidationError')
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,4 +20,5 @@ const anny = {
   validate,
 }
 
+module.exports = anny
 export default anny

--- a/test/Layer_test.js
+++ b/test/Layer_test.js
@@ -12,6 +12,10 @@ describe('Layer', () => {
   })
 
   describe('constructor', () => {
+    it('throws if "layerSize" is not a number', () => {
+      const misuse = () => new Layer()
+      expect(misuse).to.throw()
+    })
     it('creates the number of neurons specified', () => {
       const size = _.random(0, 1000)
       layer = new Layer(size)
@@ -30,10 +34,20 @@ describe('Layer', () => {
   })
 
   describe('connect', () => {
-    it('adds a bias Neuron to the source layer', () => {
+    it('adds a bias Neuron to the source layer if there is not one', () => {
       const targetLayer = new Layer(1)
+      _.some(layer.neurons, 'isBias').should.equal(false)
       layer.connect(targetLayer)
       _.some(layer.neurons, 'isBias').should.equal(true)
+    })
+    it('does not add a bias Neuron to the source layer if there is one', () => {
+      const targetLayerA = new Layer(1)
+      const targetLayerB = new Layer(1)
+      _.some(layer.neurons, 'isBias').should.equal(false)
+      layer.connect(targetLayerA)
+      _.filter(layer.neurons, 'isBias').should.have.a.lengthOf(1)
+      layer.connect(targetLayerB)
+      _.filter(layer.neurons, 'isBias').should.have.a.lengthOf(1)
     })
     it('does not add a bias Neuron to the target layer', () => {
       const targetLayer = new Layer(1)

--- a/test/Trainer_test.js
+++ b/test/Trainer_test.js
@@ -1,0 +1,26 @@
+// TODO use these old Network tests for future Trainer() class tests
+// import Network from '../src/Network'
+// import DATA from '../src/Data'
+//
+// describe('Train', () => {
+//   it('learns an OR gate', (done) => {
+//     network = new Network([2, 1])
+//     network.train(DATA.ORGate, {onSuccess: () => done()})
+//   })
+//
+//   it('learns a XOR gate', (done) => {
+//     // TODO: this should be possible with 2, 3, 1 but is intermittent.
+//     network = new Network([2, 5, 3, 1])
+//     network.train(DATA.XORGate, {onSuccess: () => done()})
+//   })
+//
+//   it('learns an AND gate', (done) => {
+//     network = new Network([2, 3, 1])
+//     network.train(DATA.ANDGate, {onSuccess: () => done()})
+//   })
+//
+//   it('learns a NAND gate', (done) => {
+//     network = new Network([2, 3, 1])
+//     network.train(DATA.NANDGate, {onSuccess: () => done()})
+//   })
+// })

--- a/test/Util_test.js
+++ b/test/Util_test.js
@@ -49,4 +49,13 @@ describe('util', () => {
       derivative(_.random()).should.be.a('number')
     })
   })
+
+  describe('type', () => {
+    it('returns the same value as Object.prototype.toString.call()', () => {
+      const types = [undefined, null, true, 0, '', [], {}, _.noop]
+      _.each(types, type => {
+        util.type(type).should.equal(Object.prototype.toString.call(type))
+      })
+    })
+  })
 })


### PR DESCRIPTION
`Network.train()` used to simply log on success or fail.  Now the method accepts options including callbacks for `onSuccess`, `onFail`, and `onProgress`.  The frequency of the `onProgress` callback can be set with the `frequency` option.  This allows calling functions at any point during training.  Training can also be cancelled by returning `false` in the `onProgress` callback.