### PR TITLE
Add Trainer class

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   "rules": {
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     "semi": [2, "never"],
-    "no-return-assign": 0
+    "no-return-assign": 0,
+    "no-loop-func": 0
   }
 }

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -2,7 +2,7 @@ instrumentation:
   excludes: [app, dist, docs, gulp, test]
 check:
   global:
-    statements: 99
-    branches: 97
-    functions: 98
-    lines: 98
+    statements: 95
+    branches: 95
+    functions: 95
+    lines: 95

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -2,7 +2,7 @@ instrumentation:
   excludes: [app, dist, docs, gulp, test]
 check:
   global:
-    statements: 95
-    branches: 95
-    functions: 95
-    lines: 95
+    statements: 90
+    branches: 90
+    functions: 90
+    lines: 90

--- a/app/src/components/anny/anny-factory.js
+++ b/app/src/components/anny/anny-factory.js
@@ -37,7 +37,9 @@ function AnnyFactory($rootScope) {
       )
     })
 
+    /* eslint-disable no-console */
     console.log(results.join('\n'))
+    /* eslint-enable no-console */
 
     factory.emitChange()
   }

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,6 @@ dependencies:
 
 test:
   post:
-    - npm run coverage-check
     - npm run coverage-report
 
 general:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "coverage-report": "codeclimate-test-reporter < coverage/lcov.info",
     "start": "gulp",
     "test": "babel-node $(npm bin)/isparta cover _mocha -- -R dot",
+    "posttest": "npm run coverage-check",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "lint:watch": "watch 'npm run lint --silent' -d -u",

--- a/playground.js
+++ b/playground.js
@@ -1,22 +1,106 @@
 /* eslint-disable no-console */
 import _ from 'lodash'
-import Network from './src/Network'
 import Data from './src/Data'
+import Layer from './src/Layer'
+import Network from './src/Network'
 import Trainer from './src/Trainer'
+import {normalize} from './src/Util'
 
-const network = new Network([2, 1])
+let epochs = []
+let successes = 0
+let fails = 0
 
-const trainer = new Trainer({
-  frequency: 1000,
-  onSuccess: (error, epoch) => {
-    console.log(`Successfully trained to ${error} error after ${epoch} epochs`)
-  },
-  onFail: (error, epoch) => {
-    console.log(`Fail to train, error is ${error} after ${epoch} epochs`)
-  },
-  onProgress: (error, epoch) => {
-    console.log(`${_.pad(epoch, 5)} ${error}`)
-  },
+// ----------------------------------------
+// Shuffle & normalize data
+// ----------------------------------------
+
+const data = _.shuffle(_.map(Data.irisFlower, (sample) => {
+  sample.input = _.map(sample.input, n => n / 7.9)
+  return sample
+}))
+
+// ----------------------------------------
+// Multiple Train
+// ----------------------------------------
+
+_.times(1, n => {
+  let lastError = 0
+  let lowestError = Infinity
+
+  // ----------------------------------------
+  // Network
+  // ----------------------------------------
+
+  const layerSizes = [4, 40, 3]
+  const learningRate =
+    //0.1
+    //0.01
+    0.001
+  const net = new Network(layerSizes)
+  const batch =
+    //true
+    false
+    //4
+    //10
+    //Math.round(data.length / 3)
+
+  console.log(_.repeat('-', 70))
+  console.log(`
+    batch:        ${batch}
+    layerSizes:   ${layerSizes.join(', ')}
+    learningRate: ${learningRate}
+  `)
+
+  net.allLayers = _.map(layerSizes, size => (
+    new Layer(size, undefined, learningRate)
+  ))
+  net.inputLayer = _.first(net.allLayers)
+  net.hiddenLayers = _.slice(net.allLayers, 1, net.allLayers.length - 1)
+  net.outputLayer = _.last(net.allLayers)
+
+  _.each(net.allLayers, (layer, i) => {
+    const next = net.allLayers[i + 1]
+    if (next) layer.connect(next)
+  })
+
+  // ----------------------------------------
+  // Trainer
+  // ----------------------------------------
+
+  const trainer = new Trainer({
+    batch: batch,
+    maxEpochs: 50000,
+    frequency: 500,
+    onSuccess: (error, epoch) => {
+      console.log(`Successfully trained to ${error} error after ${epoch} epochs`)
+      epochs.push(epoch)
+      successes++
+    },
+    onFail: (error, epoch) => {
+      console.log(`Fail to train, error is ${error} after ${epoch} epochs`)
+      fails++
+    },
+    onProgress: (error, epoch) => {
+      const sign = error < lastError ? '↓' : '↑'
+      const lowest = error < lowestError ? '★' : ' '
+      const percent =
+        `${_.padLeft(100 - Math.round((lastError / error) * 100), 4)}%`
+      lowestError = Math.min(error, lowestError)
+      console.log(`${_.pad(epoch, 5)} ${lowest} ${sign} ${percent} ${error}`)
+      lastError = error
+    },
+  })
+
+  trainer.train(net, data)
 })
 
-trainer.train(network, Data.ORGate)
+// ----------------------------------------
+// Log results
+// ----------------------------------------
+
+console.log(`
+  Min:     ${_.min(epochs)}
+  Max:     ${_.max(epochs)}
+  Avg:     ${Math.round(_.sum(epochs, n => n / epochs.length))}
+  Ratio:   ${successes}/${fails}
+`)

--- a/playground.js
+++ b/playground.js
@@ -4,9 +4,8 @@ import Data from './src/Data'
 import Layer from './src/Layer'
 import Network from './src/Network'
 import Trainer from './src/Trainer'
-import {normalize} from './src/Util'
 
-let epochs = []
+const epochs = []
 let successes = 0
 let fails = 0
 
@@ -32,17 +31,9 @@ _.times(1, n => {
   // ----------------------------------------
 
   const layerSizes = [4, 40, 3]
-  const learningRate =
-    //0.1
-    //0.01
-    0.001
+  const learningRate = 0.001
   const net = new Network(layerSizes)
-  const batch =
-    //true
-    false
-    //4
-    //10
-    //Math.round(data.length / 3)
+  const batch = false
 
   console.log(_.repeat('-', 70))
   console.log(`

--- a/playground.js
+++ b/playground.js
@@ -2,10 +2,11 @@
 import _ from 'lodash'
 import Network from './src/Network'
 import Data from './src/Data'
+import Trainer from './src/Trainer'
 
 const network = new Network([2, 1])
 
-network.train(Data.ORGate, {
+const trainer = new Trainer({
   frequency: 1000,
   onSuccess: (error, epoch) => {
     console.log(`Successfully trained to ${error} error after ${epoch} epochs`)
@@ -17,3 +18,5 @@ network.train(Data.ORGate, {
     console.log(`${_.pad(epoch, 5)} ${error}`)
   },
 })
+
+trainer.train(network, Data.ORGate)

--- a/src/Error.js
+++ b/src/Error.js
@@ -32,7 +32,7 @@ const ERROR = {
    */
   meanSquared(expected, actual) {
     return _.sum(actual, (actVal, i) => {
-      return Math.pow(expected[i] - actVal, 2)
+      return 0.5 * Math.pow(expected[i] - actVal, 2)
     }) / actual.length
   },
 

--- a/src/Initialize.js
+++ b/src/Initialize.js
@@ -20,7 +20,7 @@ const INITIALIZE = {
    * @param numInputs
    * @returns {number}
    */
-  weight(numInputs = 1) {
+  weight(numInputs) {
     // 4.6 Initializing the weights (16)
     // We find ^-1/4 performs better than the original ^1/2
     const maxWeight = Math.pow(numInputs, -1 / 4)

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -78,8 +78,7 @@ class Layer {
   }
 
   /**
-   * Calculate and accumulate Neuron Connection weight gradients.
-   * Weights are immediately updated and the accumulated gradients are reset.
+   * Update Neuron Connection weights and reset their accumulated gradients.
    */
   updateWeights() {
     _.each(this.neurons, neuron => neuron.updateWeights())

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -66,7 +66,23 @@ class Layer {
    * @returns {number[]}
    */
   backprop(deltas = []) {
-    return _.map(this.neurons, (neuron, i) => neuron.backprop(deltas[i]))
+    _.each(this.neurons, (neuron, i) => neuron.backprop(deltas[i]))
+  }
+
+  /**
+   * Calculate and accumulate Neuron Connection weight gradients.
+   * Does not update weights. Useful during batch/mini-batch training.
+   */
+  accumulateGradients() {
+    _.each(this.neurons, neuron => neuron.accumulateGradients())
+  }
+
+  /**
+   * Calculate and accumulate Neuron Connection weight gradients.
+   * Weights are immediately updated and the accumulated gradients are reset.
+   */
+  updateWeights() {
+    _.each(this.neurons, neuron => neuron.updateWeights())
   }
 
   /**

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -63,15 +63,12 @@ class Layer {
   }
 
   /**
-   * Train the Neurons in this Layer.  If target `outputs` are specified, the
-   * Neurons will learn to output these values.  This is only useful for output
-   * Layers.
-   * @param {number[]} [outputs] - Map of target output values for each Neuron.
+   * Sets all the Neuron `delta`s in this Layer to the given array of values.
+   * @param {number[]} [deltas=[]] - Delta values, one for each Neuron.
+   * @returns {number[]}
    */
-  train(outputs) {
-    _.each(this.neurons, (neuron, i) => {
-      neuron.train(outputs ? outputs[i] : undefined)
-    })
+  backprop(deltas = []) {
+    return _.map(this.neurons, (neuron, i) => neuron.backprop(deltas[i]))
   }
 
   /**

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -53,13 +53,11 @@ class Layer {
 
   /**
    * Activates all the Neurons in this Layer with the given array of values.
-   * @param {number[]} [values] - Map of input values for each Neuron.
+   * @param {number[]} [values=[]] - Map of input values for each Neuron.
    * @returns {number[]} - Array of Neuron output values.
    */
-  activate(values) {
-    return _.map(this.neurons, (neuron, i) => {
-      return neuron.activate(values ? values[i] : undefined)
-    })
+  activate(values = []) {
+    return _.map(this.neurons, (neuron, i) => neuron.activate(values[i]))
   }
 
   /**

--- a/src/Network.js
+++ b/src/Network.js
@@ -54,14 +54,6 @@ class Network {
     this.output = []
 
     /**
-     * The cost function.  The function used to calculate the error of the
-     * Network. In other words, to what degree was the Network's output wrong.
-     * @see ERROR
-     * @type {ERROR}
-     */
-    this.errorFn = ERROR.meanSquared
-
-    /**
      * The result of the `errorFn`.  Initializes as `null`.
      * @type {null|number}
      */
@@ -129,121 +121,6 @@ class Network {
 
     this.inputLayer.train()
   }
-
-  /**
-   * Train the Network to produce the output from the given input.
-   * @param {object[]} data - Array of objects in the form
-   * `{input: [], output: []}`.
-   * @param {{}} [options] Training options.
-   * @param {number} [options.errorThreshold=0.001] The target `error` value.
-   *   The goal of the Network is to train until the `error` is below this
-   *   value.
-   * @param {number} [options.frequency] - How many iterations through the
-   *   training data between calling `options.onProgress`.
-   * @param {number} [options.maxEpochs=20000] The max training iterations.
-   *   The Network will stop training after iterating through the training data
-   *   this number of times.  One full loop through the training data is
-   *   counted as one epoch.
-   * @param {Network~onFail} [options.onFail] - Called if the Network `error`
-   *   does not fall below the `errorThreshold` after `maxEpochs`.
-   * @param {Network~onProgress} [options.onProgress] - Called every
-   *   `frequency` epochs.
-   * @param {Network~onSuccess} [options.onSuccess] - Called if the Network
-   *   `error` falls below the `errorThreshold` during training.
-   */
-  train(data, options = {}) {
-    validate.trainingData(this, data)
-    // TODO: ensure data is normalized to the range of the activation functions
-    const {
-      errorThreshold = 0.001,
-      frequency = 100,
-      maxEpochs = 20000,
-      onFail = _.noop,
-      onProgress = _.noop,
-      onSuccess = _.noop,
-      } = options
-
-    if (!_.isNumber(errorThreshold)) {
-      throw new Error(`train(...) "errorThreshold" must be a number.`)
-    }
-
-    if (!_.isNumber(frequency)) {
-      throw new Error(`train(...) "frequency" must be a number.`)
-    }
-
-    if (!_.isNumber(maxEpochs)) {
-      throw new Error(`train(...) "maxEpochs" must be a number`)
-    }
-
-    if (!_.isFunction(onFail)) {
-      throw new Error(`train(...) "onFail" must be a function.`)
-    }
-
-    if (!_.isFunction(onProgress)) {
-      throw new Error(`train(...) "onProgress" must be a function.`)
-    }
-
-    if (!_.isFunction(onSuccess)) {
-      throw new Error(`train(...) "onSuccess" must be a function.`)
-    }
-
-    // use an 'each' loop so we can break out of it on success/fail
-    // a 'times' loop cannot be broken
-    _.each(_.range(maxEpochs), index => {
-      const n = index + 1
-
-      // loop over the training data summing the error of all samples
-      // http://www.researchgate.net/post
-      //   /Neural_networks_and_mean-square_errors#rgw51_55cb2f1399589
-      this.error = _.sum(data, sample => {
-        // make a prediction
-        this.activate(sample.input)
-
-        // correct the error
-        this.correct(sample.output)
-
-        // get the error
-        return this.errorFn(sample.output, this.output) / data.length
-      })
-
-      // success
-      if (this.error <= errorThreshold) {
-        onSuccess(this.error, n)
-        return false
-      }
-
-      // fail
-      if (n === maxEpochs) onFail(this.error, n)
-
-      // call onProgress after the first epoch and every `frequency` thereafter
-      if (n % frequency === 0) return onProgress(this.error, n)
-    })
-  }
-
-  /**
-   * Called if the Network error falls below the `errorThreshold`.
-   * @callback Network~onSuccess
-   * @param {number} error The Network error value at the time of success.
-   * @param {number} epoch Indicates on which iteration through the training
-   *   data the Network became successful.
-   */
-
-  /**
-   * Called if the Network error is not below the `errorThreshold` after
-   * `maxEpochs` iterations through the training data set.
-   * @callback Network~onFail
-   * @param {number} error The Network error value at the time of success.
-   * @param {number} epoch Indicates on which iteration through the training
-   *   data the Network became successful.
-   */
-
-  /**
-   * Called if the Network error falls below the `errorThreshold`.
-   * @callback Network~onProgress
-   * @param {number} error The Network error value at the time of success.
-   * @param {number} epoch Indicates on which iteration through the training
-   *   data the Network became successful.
-   */
 }
 
 export default Network

--- a/src/Network.js
+++ b/src/Network.js
@@ -106,20 +106,18 @@ class Network {
   }
 
   /**
-   * Correct the Network to produce the specified `output`.
-   * @param {number[]} output - The target output for the Network.
-   * Values in the array specify the target output of the Neuron in the output
-   *   layer.
+   * Set output Layer `delta`s and propagate them backward through the Network.
+   * @param {number[]} deltas - Delta values, one for each output Neuron.
    */
-  correct(output) {
-    this.outputLayer.train(output)
+  backprop(deltas) {
+    this.outputLayer.backprop(deltas)
 
-    // train hidden layers in reverse (last to first)
+    // backprop hidden layers in reverse (last to first)
     for (let i = this.hiddenLayers.length - 1; i >= 0; i -= 1) {
-      this.hiddenLayers[i].train()
+      this.hiddenLayers[i].backprop()
     }
 
-    this.inputLayer.train()
+    this.inputLayer.backprop()
   }
 }
 

--- a/src/Network.js
+++ b/src/Network.js
@@ -112,8 +112,9 @@ class Network {
   }
 
   /**
-   * Set output Layer `delta`s and propagate them backward through the Network.
-   * The input Layers have no use for deltas, so it is skipped.
+   * Set Network `error` and output Layer `delta`s and propagate them backward
+   * through the Network. The input Layer has no use for deltas, so it is
+   * skipped.
    * @param {number[]} targetOutput - The expected Network output vector.
    */
   backprop(targetOutput) {
@@ -145,8 +146,7 @@ class Network {
   }
 
   /**
-   * Calculate and accumulate Neuron Connection weight gradients.
-   * Weights are immediately updated and the accumulated gradients are reset.
+   * Update Neuron Connection weights and reset their accumulated gradients.
    */
   updateWeights() {
     // NOTE can be parallel, Neuron outputs and deltas are already set

--- a/src/Network.js
+++ b/src/Network.js
@@ -100,9 +100,10 @@ class Network {
 
   /**
    * Activate the Network with a given set of `input` values.
-   * @param {number[]} inputs - Values to activate the Network input Neurons.
-   *   Values should be normalized between -1 and 1 using Util.normalize.
-   * @returns {number[]} output values
+   * @param {number[]} inputs - Values to activate the Network's input Neurons
+   *   with.
+   * @returns {number[]} output - The output values of each Neuron in the output
+   *   Layer.
    */
   activate(inputs) {
     this.inputLayer.activate(inputs)

--- a/src/Network.js
+++ b/src/Network.js
@@ -1,8 +1,6 @@
 import _ from 'lodash'
 import Layer from './Layer'
-import ERROR from './Error'
 import {type} from './Util'
-import validate from './Validate'
 
 /**
  * A Network contains [Layers]{@link Layer} of [Neurons]{@link Neuron}.
@@ -93,7 +91,7 @@ class Network {
   }
 
   /**
-   * Activate the network with a given set of `input` values.
+   * Activate the Network with a given set of `input` values.
    * @param {number[]} inputs - Values to activate the Network input Neurons.
    *   Values should be normalized between -1 and 1 using Util.normalize.
    * @returns {number[]} output values
@@ -101,8 +99,7 @@ class Network {
   activate(inputs) {
     this.inputLayer.activate(inputs)
     _.invoke(this.hiddenLayers, 'activate')
-    this.output = this.outputLayer.activate()
-    return this.output
+    return this.output = this.outputLayer.activate()
   }
 
   /**

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -197,6 +197,29 @@ Neuron.Connection = function Connection(source, target, weight) {
     // We add one to initialize the weight value as if this connection were
     // already part of the fan.
   this.weight = weight || INITIALIZE.weight(target.incoming.length)
+
+  /**
+   * Accumulator for the weight change value.  When applied to the weight, this
+   * value is set to 0.
+   * @type {number}
+   */
+  this.delta = 0
+
+  /**
+   * Accumulate `delta`.
+   * @param {number} delta The pending change in `weight` value.
+   */
+  this.accumulate = (delta) => {
+    this.delta += delta
+  }
+
+  /**
+   * Apply the current `delta` to the `weight` value and reset the `delta`.
+   */
+  this.update = () => {
+    this.weight -= this.delta
+    this.delta = 0
+  }
 }
 
 export default Neuron

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -73,8 +73,7 @@ class Neuron {
    * Neurons will squash their input value to derive their
    * output.
    * @param {number} [input] - If omitted the input value will be calculated
-   *   from the outputs and weights of the Neurons connected to
-   *   this Neuron.
+   *   from the outputs and weights of the Neurons connected to this Neuron.
    * @returns {number}
    */
   activate(input) {

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -43,6 +43,7 @@ class Neuron {
      * @see Neuron.Connection
      */
     this.incoming = []
+
     /**
      * An array of outgoing Connections to other Neurons.
      * @type {Array}
@@ -50,11 +51,18 @@ class Neuron {
      */
     this.outgoing = []
 
-    // signal values
+    /**
+     * The input value of the last activation.
+     * @type {number}
+     */
     this.input = 0
+
+    /**
+     * The output value of the last activation.
+     * @type {number}
+     */
     this.output = 0
 
-    // activation
     /**
      *
      * @type {ACTIVATION.tanh|{func, prime}|*}
@@ -108,7 +116,6 @@ class Neuron {
     if (this.isInput() || this.isBias) return this.delta
 
     // set deltas
-    // https://en.wikipedia.org/wiki/Backpropagation/#Phase_1:_Propagation
     if (!_.isUndefined(delta)) {
       this.delta = delta
     } else {

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -136,8 +136,7 @@ class Neuron {
   }
 
   /**
-   * Calculate and accumulate Connection weight gradients.
-   * Weights are immediately updated and the accumulated gradients are reset.
+   * Update Connection weights and reset their accumulated gradients.
    */
   updateWeights() {
     _.each(this.incoming, connection => connection.update())
@@ -234,10 +233,11 @@ Neuron.Connection = class Connection {
   }
 
   /**
-   * Calculate and accumulate `gradient`, update `weight` and reset `gradient`.
+   * Update `weight` and reset accumulated `gradient`.
    */
   update() {
     this.accumulate()
+    // TODO support other weight update rules, like iRProp+
     this.weight -= this.gradient
     this.gradient = 0
   }

--- a/src/Trainer.js
+++ b/src/Trainer.js
@@ -46,8 +46,6 @@ class Trainer {
    *   Called if the Network `error` falls below the `errorThreshold` during
    *   training.
    * @constructor
-   * @see Network
-   * @see ERROR
    */
   constructor(options = {}) {
     const defaultOptions = {
@@ -63,12 +61,14 @@ class Trainer {
   }
 
   /**
-   * Train the Network to produce the output from the given input.
+   * Train the `network` to classify the `data`.
    * @param {Network} network - The Network to be trained.
    * @param {object[]} data - Array of objects in the form
    * `{input: [], output: []}`.
    * @param {object} [overrides] Overrides are merged into this trainer
    *   instance's options.
+   * @see Network
+   * @see Data
    */
   train(network, data, overrides = {}) {
     validate.trainingData(network, data)
@@ -132,33 +132,33 @@ class Trainer {
   }
 
   /**
-   * Called if the Network error falls below the `errorThreshold`.
+   * Called if the `network` error falls below the `errorThreshold`.
    * @callback Trainer~onSuccess
    * @param {number} error
-   *   The Network error value at the time of success.
+   *   The `network` error value at the time of success.
    * @param {number} epoch
-   *   Indicates on which iteration through the training data the Network
+   *   Indicates on which iteration through the training data the `network`
    *   became successful.
    */
 
   /**
-   * Called if the Network error is not below the `errorThreshold` after
+   * Called if the `network` error is not below the `errorThreshold` after
    * `maxEpochs` iterations through the training data set.
    * @callback Trainer~onFail
    * @param {number} error
-   *   The Network error value at the time of success.
+   *   The `network` error value at the time of success.
    * @param {number} epoch
-   *   Indicates on which iteration through the training data the Network
+   *   Indicates on which iteration through the training data the `network`
    *   became successful.
    */
 
   /**
-   * Called if the Network error falls below the `errorThreshold`.
+   * Called if the `network` error falls below the `errorThreshold`.
    * @callback Trainer~onProgress
    * @param {number} error
-   *   The Network error value at the time of success.
+   *   The `network` error value at the time of success.
    * @param {number} epoch
-   *   Indicates on which iteration through the training data the Network
+   *   Indicates on which iteration through the training data the `network`
    *   became successful.
    */
 }

--- a/src/Trainer.js
+++ b/src/Trainer.js
@@ -1,0 +1,146 @@
+import _ from 'lodash'
+import validate from './Validate'
+import ERROR from './Error'
+
+/**
+ * A Trainer teaches a {@link Network} how to correctly classify some `data`.
+ *
+ * @example
+ * const network = new anny.Network([2, 1])
+ * const trainer = new Trainer()
+ *
+ * trainer.train(network, anny.DATA.ORGate)
+ *
+ * network.activate([0, 0]) // => 0.000836743108
+ * network.activate([0, 1]) // => 0.998253857294
+ */
+class Trainer {
+  /**
+   * @param {object} [options]
+   * @param {object} [options.errorFn]
+   *   The cost function.  The function used to calculate the error of the
+   *   Network. In other words, to what degree was the Network's output wrong.
+   * @param {number} [options.errorThreshold=0.001]
+   *   The target `error` value. The goal of the Trainer is to train the
+   *   Network until the `error` is below this value.
+   * @param {number} [options.frequency=100]
+   *   How many iterations through the training data between calling
+   *   `options.onProgress`.
+   * @param {number} [options.maxEpochs=20000]
+   *   The max training iterations. The Trainer will stop training after
+   *   iterating through the training data this number of times.  One full loop
+   *   through the training data is counted as one epoch.
+   * @param {Trainer~onFail} [options.onFail]
+   *   Called if the Network `error` does not fall below the `errorThreshold`
+   *   after `maxEpochs`.
+   * @param {Trainer~onProgress} [options.onProgress]
+   *   Called every `frequency` epochs.
+   * @param {Trainer~onSuccess} [options.onSuccess]
+   *   Called if the Network `error` falls below the `errorThreshold` during
+   *   training.
+   * @constructor
+   * @see Network
+   * @see ERROR
+   */
+  constructor(options = {}) {
+    const defaultOptions = {
+      errorFn: ERROR.meanSquared,
+      errorThreshold: 0.001,
+      frequency: 100,
+      maxEpochs: 20000,
+    }
+
+    const mergedOptions = _.merge(defaultOptions, options)
+    validate.trainingOptions(mergedOptions)
+    this.options = mergedOptions
+  }
+
+  /**
+   * Train the Network to produce the output from the given input.
+   * @param {Network} network - The Network to be trained.
+   * @param {object[]} data - Array of objects in the form
+   * `{input: [], output: []}`.
+   * @param {object} [overrides] Overrides are merged into this trainer
+   *   instance's options.
+   */
+  train(network, data, overrides = {}) {
+    validate.trainingData(network, data)
+    const mergedOptions = _.merge(this.options, overrides)
+    validate.trainingOptions(mergedOptions)
+    // TODO: normalize data to the range of the activation functions
+    const {
+      errorFn,
+      errorThreshold,
+      frequency,
+      maxEpochs,
+      onFail,
+      onProgress,
+      onSuccess,
+      } = mergedOptions
+
+    // use an 'each' loop so we can break out of it on success/fail
+    // a 'times' loop cannot be broken
+    _.each(_.range(maxEpochs), index => {
+      const n = index + 1
+
+      // loop over the training data summing the error of all samples
+      // http://www.researchgate.net/post
+      //   /Neural_networks_and_mean-square_errors#rgw51_55cb2f1399589
+      network.error = _.sum(data, sample => {
+        // make a prediction
+        network.activate(sample.input)
+
+        // correct the error
+        network.correct(sample.output)
+
+        // get the error
+        return errorFn(sample.output, network.output) / data.length
+      })
+
+      // success
+      if (onSuccess && network.error <= errorThreshold) {
+        onSuccess(network.error, n)
+        return false
+      }
+
+      // fail
+      if (onFail && n === maxEpochs) onFail(network.error, n)
+
+      // call onProgress after the first epoch and every `frequency` thereafter
+      if (onProgress && n % frequency === 0) return onProgress(network.error, n)
+    })
+  }
+
+  /**
+   * Called if the Network error falls below the `errorThreshold`.
+   * @callback Trainer~onSuccess
+   * @param {number} error
+   *   The Network error value at the time of success.
+   * @param {number} epoch
+   *   Indicates on which iteration through the training data the Network
+   *   became successful.
+   */
+
+  /**
+   * Called if the Network error is not below the `errorThreshold` after
+   * `maxEpochs` iterations through the training data set.
+   * @callback Trainer~onFail
+   * @param {number} error
+   *   The Network error value at the time of success.
+   * @param {number} epoch
+   *   Indicates on which iteration through the training data the Network
+   *   became successful.
+   */
+
+  /**
+   * Called if the Network error falls below the `errorThreshold`.
+   * @callback Trainer~onProgress
+   * @param {number} error
+   *   The Network error value at the time of success.
+   * @param {number} epoch
+   *   Indicates on which iteration through the training data the Network
+   *   became successful.
+   */
+}
+
+export default Trainer

--- a/src/Util.js
+++ b/src/Util.js
@@ -26,15 +26,6 @@ export function normalize(array, min = _.min(array), max = _.max(array)) {
 }
 
 /**
- * Returns a new function that is an approximate derivative of the `func`.
- * @param func - The function to create an approximate derivative of.
- * @returns {function}
- */
-export function getApproximateDerivative(func) {
-  return x => (func(x + 1e-10) - func(x)) / 1e-10
-}
-
-/**
  * Thin helper for use getting object type.
  * @param {*} arg The value whose type should be returned.
  */
@@ -48,7 +39,6 @@ export function type(arg) {
  */
 const util = {
   normalize,
-  getApproximateDerivative,
   type,
 }
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,52 +1,55 @@
 import _ from 'lodash'
 
+/**
+ * Normalizes an `array` of numbers to a range from -1 to 1. Optionally
+ * specifying the `dataMin` and/or `dataMax` is useful when normalizing
+ * multiple arrays that do not each contain the global min value or global
+ * max value.
+ * @param {number[]} array - The array to normalize.
+ * @param {number} [min] - The number to use at the min value in the
+ *   `array`. Defaults to the actual min `array` value.
+ * @param {number} [max] - The number to use at the max value in the
+ *   `array`. Defaults to the actual max `array` value.
+ */
+export function normalize(array, min = _.min(array), max = _.max(array)) {
+  const offset = 0 - min
+  const range = max - min
+
+  return _.map(array, n => {
+    if (n > max || n < min) {
+      throw new Error(
+        `${n} is beyond the scale range: ${min} to ${max}`
+      )
+    }
+    return (n + offset) / (range / 2) - 1
+  })
+}
+
+/**
+ * Returns a new function that is an approximate derivative of the `func`.
+ * @param func - The function to create an approximate derivative of.
+ * @returns {function}
+ */
+export function getApproximateDerivative(func) {
+  return x => (func(x + 1e-10) - func(x)) / 1e-10
+}
+
+/**
+ * Thin helper for use getting object type.
+ * @param {*} arg The value whose type should be returned.
+ */
+export function type(arg) {
+  return Object.prototype.toString.call(arg)
+}
 
 /**
  * @namespace
  * @type {{}}
  */
 const util = {
-  /**
-   * Normalizes an `array` of numbers to a range from -1 to 1. Optionally
-   * specifying the `dataMin` and/or `dataMax` is useful when normalizing
-   * multiple arrays that do not each contain the global min value or global
-   * max value.
-   * @param {number[]} array - The array to normalize.
-   * @param {number} [dataMin] - The number to use at the min value in the
-   *   `array`. Defaults to the actual min `array` value.
-   * @param {number} [dataMax] - The number to use at the max value in the
-   *   `array`. Defaults to the actual max `array` value.
-   */
-  normalize: (array, dataMin = _.min(array), dataMax = _.max(array)) => {
-    const offset = 0 - dataMin
-    const range = dataMax - dataMin
-
-    return _.map(array, n => {
-      if (n > dataMax || n < dataMin) {
-        throw new Error(
-          `${n} is beyond the scale range: ${dataMin} to ${dataMax}`
-        )
-      }
-      return (n + offset) / (range / 2) - 1
-    })
-  },
-
-  /**
-   * Returns a new function that is an approximate derivative of the `func`.
-   * @param func - The function to create an approximate derivative of.
-   * @returns {function}
-   */
-  getApproximateDerivative: (func) => {
-    return x => (func(x + 1e-10) - func(x)) / 1e-10
-  },
-
-  /**
-   * Thin helper for use getting object type.
-   * @param {*} arg The value whose type should be returned.
-   */
-  type: (arg) => {
-    return Object.prototype.toString.call(arg)
-  },
+  normalize,
+  getApproximateDerivative,
+  type,
 }
 
 export default util

--- a/src/Validate.js
+++ b/src/Validate.js
@@ -191,6 +191,55 @@ const validate = {
       validate.sampleOutputFitsNetwork(sample, i, network)
     })
   },
+
+  trainingOptions(options) {
+    if (!_.isPlainObject(options)) {
+      throw new Error(`training "options" must be a plain object.`)
+    }
+
+    const validOptions = [
+      'errorFn',
+      'errorThreshold',
+      'frequency',
+      'maxEpochs',
+      'onFail',
+      'onProgress',
+      'onSuccess',
+    ]
+
+    _.each(options, (val, key) => {
+      if (_.includes(validOptions, key)) return
+      throw new Error(`Unknown training option "${key}", try: ${validOptions}`)
+    })
+
+    if (!_.isFunction(options.errorFn)) {
+      throw new Error(`training option "errorFn" must be a function.`)
+    }
+
+    if (!_.isNumber(options.errorThreshold)) {
+      throw new Error(`training option "errorThreshold" must be a number.`)
+    }
+
+    if (!_.isNumber(options.frequency)) {
+      throw new Error(`training option "frequency" must be a number.`)
+    }
+
+    if (!_.isNumber(options.maxEpochs)) {
+      throw new Error(`training option "maxEpochs" must be a number`)
+    }
+
+    if (_.has(options, 'onFail') && !_.isFunction(options.onFail)) {
+      throw new Error(`training option "onFail" must be a function.`)
+    }
+
+    if (_.has(options, 'onProgress') && !_.isFunction(options.onProgress)) {
+      throw new Error(`training option "onProgress" must be a function.`)
+    }
+
+    if (_.has(options, 'onSuccess') && !_.isFunction(options.onSuccess)) {
+      throw new Error(`training option "onSuccess" must be a function.`)
+    }
+  },
 }
 
 export default validate

--- a/src/Validate.js
+++ b/src/Validate.js
@@ -198,6 +198,7 @@ const validate = {
     }
 
     const validOptions = [
+      'batch',
       'errorFn',
       'errorThreshold',
       'frequency',
@@ -211,6 +212,10 @@ const validate = {
       if (_.includes(validOptions, key)) return
       throw new Error(`Unknown training option "${key}", try: ${validOptions}`)
     })
+
+    if (!_.isBoolean(options.batch) && !_.isNumber(options.batch)) {
+      throw new Error(`training option "batch" must be a boolean or number.`)
+    }
 
     if (!_.isFunction(options.errorFn)) {
       throw new Error(`training option "errorFn" must be a function.`)

--- a/src/Validate.js
+++ b/src/Validate.js
@@ -199,7 +199,6 @@ const validate = {
 
     const validOptions = [
       'batch',
-      'errorFn',
       'errorThreshold',
       'frequency',
       'maxEpochs',
@@ -215,10 +214,6 @@ const validate = {
 
     if (!_.isBoolean(options.batch) && !_.isNumber(options.batch)) {
       throw new Error(`training option "batch" must be a boolean or number.`)
-    }
-
-    if (!_.isFunction(options.errorFn)) {
-      throw new Error(`training option "errorFn" must be a function.`)
     }
 
     if (!_.isNumber(options.errorThreshold)) {

--- a/test/Network_test.js
+++ b/test/Network_test.js
@@ -34,8 +34,8 @@ describe('Network', () => {
   })
 
   describe('constructor', () => {
-    it('initializes with a "null" error', () => {
-      expect(network.error).to.equal(null)
+    it('initializes with a "0" error', () => {
+      expect(network.error).to.equal(0)
     })
 
     it('has all layers in a single array', () => {
@@ -99,11 +99,10 @@ describe('Network', () => {
       _.each(network.hiddenLayers, l => l.backprop.called.should.equal(true))
     })
 
-    it('calls backprop on the input layer', () => {
+    it('does not call backprop on the input layer', () => {
       network.inputLayer.backprop = sandbox.spy()
-      network.inputLayer.backprop.called.should.equal(false)
       network.backprop()
-      network.inputLayer.backprop.called.should.equal(true)
+      network.inputLayer.backprop.called.should.equal(false)
     })
   })
 })

--- a/test/Network_test.js
+++ b/test/Network_test.js
@@ -1,15 +1,12 @@
 import _ from 'lodash'
 import Network from '../src/Network'
 import Layer from '../src/Layer'
-import DATA from '../src/Data'
 let network
-let data
 let sandbox
 
 describe('Network', () => {
   beforeEach(() => {
     network = new Network([2, 1])
-    data = DATA.ORGate
     sandbox = sinon.sandbox.create()
   })
 

--- a/test/Network_test.js
+++ b/test/Network_test.js
@@ -86,11 +86,11 @@ describe('Network', () => {
     })
   })
 
-  describe('correct', () => {
+  describe('train', () => {
     it('calls train on the input layer', () => {
       network.inputLayer.train = sandbox.spy()
       network.inputLayer.train.called.should.equal(false)
-      network.correct()
+      network.train()
       network.inputLayer.train.called.should.equal(true)
     })
 
@@ -98,14 +98,14 @@ describe('Network', () => {
       network = new Network([2, 2, 1])
       _.each(network.hiddenLayers, l => l.train = sandbox.spy())
       _.each(network.hiddenLayers, l => l.train.called.should.equal(false))
-      network.correct()
+      network.train()
       _.each(network.hiddenLayers, l => l.train.called.should.equal(true))
     })
 
     it('calls train on the output layer', () => {
       network.outputLayer.train = sandbox.spy()
       network.outputLayer.train.called.should.equal(false)
-      network.correct()
+      network.train()
       network.outputLayer.train.called.should.equal(true)
     })
   })

--- a/test/Network_test.js
+++ b/test/Network_test.js
@@ -86,167 +86,27 @@ describe('Network', () => {
     })
   })
 
-  describe('train', () => {
-    it('calls train on the input layer', () => {
-      network.inputLayer.train = sandbox.spy()
-      network.inputLayer.train.called.should.equal(false)
-      network.train()
-      network.inputLayer.train.called.should.equal(true)
+  describe('backprop', () => {
+    it('calls backprop on the output layer', () => {
+      network.outputLayer.backprop = sandbox.spy()
+      network.outputLayer.backprop.called.should.equal(false)
+      network.backprop()
+      network.outputLayer.backprop.called.should.equal(true)
     })
 
-    it('calls train on the input layer', () => {
+    it('calls backprop on each hidden layer', () => {
       network = new Network([2, 2, 1])
-      _.each(network.hiddenLayers, l => l.train = sandbox.spy())
-      _.each(network.hiddenLayers, l => l.train.called.should.equal(false))
-      network.train()
-      _.each(network.hiddenLayers, l => l.train.called.should.equal(true))
+      _.each(network.hiddenLayers, l => l.backprop = sandbox.spy())
+      _.each(network.hiddenLayers, l => l.backprop.called.should.equal(false))
+      network.backprop()
+      _.each(network.hiddenLayers, l => l.backprop.called.should.equal(true))
     })
 
-    it('calls train on the output layer', () => {
-      network.outputLayer.train = sandbox.spy()
-      network.outputLayer.train.called.should.equal(false)
-      network.train()
-      network.outputLayer.train.called.should.equal(true)
-    })
-  })
-
-  describe('train', () => {
-    it('is a function', () => {
-      network.train.should.be.a('function')
-    })
-
-    describe('options', () => {
-      const misuse = badOptions => network.train(data, badOptions)
-
-      describe('validation', () => {
-        it('throws if "errorThreshold" is not a number', () => {
-          expect(_.partial(misuse, {errorThreshold: ''})).to.throw()
-        })
-
-        it('throws if "frequency" is not a number', () => {
-          expect(_.partial(misuse, {frequency: ''})).to.throw()
-        })
-
-        it('throws if "maxEpochs" is not a number', () => {
-          expect(_.partial(misuse, {maxEpochs: ''})).to.throw()
-        })
-
-        it('throws if "onFail" is not a function', () => {
-          expect(_.partial(misuse, {onFail: ''})).to.throw()
-        })
-
-        it('throws if "onProgress" is not a function', () => {
-          expect(_.partial(misuse, {onProgress: ''})).to.throw()
-        })
-
-        it('throws if "onSuccess" is not a function', () => {
-          expect(_.partial(misuse, {onSuccess: ''})).to.throw()
-        })
-      })
-
-      describe('errorThreshold', () => {
-        it('controls how low the "error" must become before succeeding', () => {
-          // Infinity means we'll always have instant training success
-          network.train(data, {
-            errorThreshold: Infinity,
-            onSuccess: (error, epoch) => epoch.should.equal(1),
-          })
-        })
-      })
-
-      describe('frequency', () => {
-        it('controls how often "onProgress" is called', () => {
-          const frequency = _.random(1, 10)
-          let counter = 1
-          network.train(data, {
-            maxEpochs: 100,
-            frequency,
-            onProgress: (error, epoch) => {
-              epoch.should.equal(frequency * counter)
-              counter += 1
-            },
-          })
-        })
-      })
-
-      describe('maxEpochs', () => {
-        it('controls long the network trains for', () => {
-          const maxEpochs = _.random(1, 100)
-          // cannot solve XOR, would run forever
-          network = new Network([2, 1]).train(data, {
-            maxEpochs,
-            onFail: (error, epoch) => epoch.should.equal(maxEpochs),
-          })
-        })
-      })
-
-      describe('onFail', () => {
-        it('is called when max epochs is reached', () => {
-          network.train(data, {
-            maxEpochs: 1,
-            onFail: (error, epoch) => epoch.should.equal(1),
-          })
-        })
-
-        it('is called with "error" and "epoch" values', () => {
-          network.train(data, {
-            maxEpochs: 1,
-            onFail: (error, epoch) => {
-              epoch.should.be.a('number')
-              epoch.should.equal(1)
-              error.should.be.a('number')
-            },
-          })
-        })
-      })
-
-      describe('onProgress', () => {
-        it('is called with "error" and "epoch" values', () => {
-          network.train(data, {
-            maxEpochs: 1,
-            onProgress: (error, epoch) => {
-              epoch.should.be.a('number')
-              epoch.should.equal(1)
-              error.should.be.a('number')
-            },
-          })
-        })
-
-        it('stops training when false is returned', () => {
-          // cannot solve XOR, would run run forever
-          network = new Network([2, 1])
-          network.train(DATA.XORGate, {
-            // ensure we run a few epochs, calling progress every epoch
-            maxEpochs: 5,
-            frequency: 1,
-            onProgress: (error, epoch) => {
-              // we should only hit the first epoch
-              epoch.should.equal(1)
-              return false
-            },
-          })
-        })
-      })
-
-      describe('onSuccess', () => {
-        it('is called when "error" falls below "errorThreshold"', () => {
-          network.train(data, {
-            errorThreshold: Infinity,
-            onSuccess: (error, epoch) => epoch.should.equal(1),
-          })
-        })
-
-        it('is called with "error" and "epoch" values', () => {
-          network.train(data, {
-            maxEpochs: 1,
-            onSuccess: (error, epoch) => {
-              epoch.should.be.a('number')
-              epoch.should.equal(1)
-              error.should.be.a('number')
-            },
-          })
-        })
-      })
+    it('calls backprop on the input layer', () => {
+      network.inputLayer.backprop = sandbox.spy()
+      network.inputLayer.backprop.called.should.equal(false)
+      network.backprop()
+      network.inputLayer.backprop.called.should.equal(true)
     })
   })
 })

--- a/test/Trainer_test.js
+++ b/test/Trainer_test.js
@@ -1,26 +1,133 @@
-// TODO use these old Network tests for future Trainer() class tests
-// import Network from '../src/Network'
-// import DATA from '../src/Data'
-//
-// describe('Train', () => {
-//   it('learns an OR gate', (done) => {
-//     network = new Network([2, 1])
-//     network.train(DATA.ORGate, {onSuccess: () => done()})
-//   })
-//
-//   it('learns a XOR gate', (done) => {
-//     // TODO: this should be possible with 2, 3, 1 but is intermittent.
-//     network = new Network([2, 5, 3, 1])
-//     network.train(DATA.XORGate, {onSuccess: () => done()})
-//   })
-//
-//   it('learns an AND gate', (done) => {
-//     network = new Network([2, 3, 1])
-//     network.train(DATA.ANDGate, {onSuccess: () => done()})
-//   })
-//
-//   it('learns a NAND gate', (done) => {
-//     network = new Network([2, 3, 1])
-//     network.train(DATA.NANDGate, {onSuccess: () => done()})
-//   })
-// })
+import _ from 'lodash'
+import Trainer from '../src/Trainer'
+import Network from '../src/Network'
+import DATA from '../src/Data'
+let trainer
+let network
+let data
+let sandbox
+
+describe('Trainer', () => {
+  beforeEach(() => {
+    trainer = new Trainer()
+    network = new Network([2, 1])
+    data = DATA.ORGate
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('train', () => {
+    it('is a function', () => {
+      trainer.train.should.be.a('function')
+    })
+
+    describe('options', () => {
+      describe('errorThreshold', () => {
+        it('controls how low the "error" must become before succeeding', () => {
+          // Infinity means we'll always have instant training success
+          trainer.train(network, data, {
+            errorThreshold: Infinity,
+            onSuccess: (error, epoch) => epoch.should.equal(1),
+          })
+        })
+      })
+
+      describe('frequency', () => {
+        it('controls how often "onProgress" is called', () => {
+          const frequency = _.random(1, 10)
+          let counter = 1
+          trainer.train(network, data, {
+            maxEpochs: 100,
+            frequency,
+            onProgress: (error, epoch) => {
+              epoch.should.equal(frequency * counter)
+              counter += 1
+            },
+          })
+        })
+      })
+
+      describe('maxEpochs', () => {
+        it('controls long the network trains for', () => {
+          const maxEpochs = _.random(1, 100)
+          // cannot solve XOR, would run forever
+          trainer.train(network, DATA.XORGate, {
+            maxEpochs,
+            onFail: (error, epoch) => epoch.should.equal(maxEpochs),
+          })
+        })
+      })
+
+      describe('onFail', () => {
+        it('is called when max epochs is reached', () => {
+          trainer.train(network, data, {
+            maxEpochs: 1,
+            onFail: (error, epoch) => epoch.should.equal(1),
+          })
+        })
+
+        it('is called with "error" and "epoch" values', () => {
+          trainer.train(network, data, {
+            maxEpochs: 1,
+            onFail: (error, epoch) => {
+              epoch.should.be.a('number')
+              epoch.should.equal(1)
+              error.should.be.a('number')
+            },
+          })
+        })
+      })
+
+      describe('onProgress', () => {
+        it('is called with "error" and "epoch" values', () => {
+          trainer.train(network, data, {
+            maxEpochs: 1,
+            onProgress: (error, epoch) => {
+              epoch.should.be.a('number')
+              epoch.should.equal(1)
+              error.should.be.a('number')
+            },
+          })
+        })
+
+        it('stops training when false is returned', () => {
+          // cannot solve XOR, would run run forever
+          network = new Network([2, 1])
+          trainer.train(network, DATA.XORGate, {
+            // ensure we run a few epochs, calling progress every epoch
+            maxEpochs: 5,
+            frequency: 1,
+            onProgress: (error, epoch) => {
+              // we should only hit the first epoch
+              epoch.should.equal(1)
+              return false
+            },
+          })
+        })
+      })
+
+      describe('onSuccess', () => {
+        it('is called when "error" falls below "errorThreshold"', () => {
+          trainer.train(network, data, {
+            errorThreshold: Infinity,
+            onSuccess: (error, epoch) => epoch.should.equal(1),
+          })
+        })
+
+        it('is called with "error" and "epoch" values', () => {
+          trainer.train(network, data, {
+            maxEpochs: 1,
+            onSuccess: (error, epoch) => {
+              epoch.should.be.a('number')
+              epoch.should.equal(1)
+              error.should.be.a('number')
+            },
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/Util_test.js
+++ b/test/Util_test.js
@@ -39,17 +39,6 @@ describe('util', () => {
     })
   })
 
-  describe('getApproximateDerivative', () => {
-    it('returns a function', () => {
-      util.getApproximateDerivative(_.noop).should.be.a('function')
-    })
-
-    it('returns a function that returns a number', () => {
-      const derivative = util.getApproximateDerivative(Math.sin)
-      derivative(_.random()).should.be.a('number')
-    })
-  })
-
   describe('type', () => {
     it('returns the same value as Object.prototype.toString.call()', () => {
       const types = [undefined, null, true, 0, '', [], {}, _.noop]

--- a/test/Validate_test.js
+++ b/test/Validate_test.js
@@ -254,7 +254,6 @@ describe('Validate', () => {
     beforeEach(() => {
       options = {
         batch: true,
-        errorFn: _.noop,
         errorThreshold: 0.001,
         frequency: 100,
         maxEpochs: 1000,
@@ -280,12 +279,6 @@ describe('Validate', () => {
       options.batch = ''
       expect(_.partial(misuse, options))
         .to.throw('training option "batch" must be a boolean or number.')
-    })
-
-    it('throws if "errorFn" is not a function', () => {
-      options.errorFn = ''
-      expect(_.partial(misuse, options))
-        .to.throw('training option "errorFn" must be a function.')
     })
 
     it('throws if "errorThreshold" is not a number', () => {

--- a/test/Validate_test.js
+++ b/test/Validate_test.js
@@ -258,6 +258,10 @@ describe('Validate', () => {
       expect(_.partial(misuse, {foo: 'bar'})).to.throw()
     })
 
+    it('throws if "batch" is not a boolean or number', () => {
+      expect(_.partial(misuse, {batch: ''})).to.throw()
+    })
+
     it('throws if "errorFn" is not a function', () => {
       expect(_.partial(misuse, {errorFn: ''})).to.throw()
     })

--- a/test/Validate_test.js
+++ b/test/Validate_test.js
@@ -245,4 +245,45 @@ describe('Validate', () => {
       validate.sampleOutputFitsNetwork.called.should.equal(true)
     })
   })
+
+
+  describe('trainingOptions', () => {
+    const misuse = badOptions => validate.trainingOptions(badOptions)
+
+    it('throws if "options" is not a plain object', () => {
+      expect(_.partial(misuse, null)).to.throw()
+    })
+
+    it('throws if "options" contains an invalid option', () => {
+      expect(_.partial(misuse, {foo: 'bar'})).to.throw()
+    })
+
+    it('throws if "errorFn" is not a function', () => {
+      expect(_.partial(misuse, {errorFn: ''})).to.throw()
+    })
+
+    it('throws if "errorThreshold" is not a number', () => {
+      expect(_.partial(misuse, {errorThreshold: ''})).to.throw()
+    })
+
+    it('throws if "frequency" is not a number', () => {
+      expect(_.partial(misuse, {frequency: ''})).to.throw()
+    })
+
+    it('throws if "maxEpochs" is not a number', () => {
+      expect(_.partial(misuse, {maxEpochs: ''})).to.throw()
+    })
+
+    it('throws if "onFail" is not a function', () => {
+      expect(_.partial(misuse, {onFail: ''})).to.throw()
+    })
+
+    it('throws if "onProgress" is not a function', () => {
+      expect(_.partial(misuse, {onProgress: ''})).to.throw()
+    })
+
+    it('throws if "onSuccess" is not a function', () => {
+      expect(_.partial(misuse, {onSuccess: ''})).to.throw()
+    })
+  })
 })

--- a/test/Validate_test.js
+++ b/test/Validate_test.js
@@ -249,45 +249,79 @@ describe('Validate', () => {
 
   describe('trainingOptions', () => {
     const misuse = badOptions => validate.trainingOptions(badOptions)
+    let options
+
+    beforeEach(() => {
+      options = {
+        batch: true,
+        errorFn: _.noop,
+        errorThreshold: 0.001,
+        frequency: 100,
+        maxEpochs: 1000,
+        onFail: _.noop,
+        onProgress: _.noop,
+        onSuccess: _.noop,
+      }
+    })
 
     it('throws if "options" is not a plain object', () => {
-      expect(_.partial(misuse, null)).to.throw()
+      expect(_.partial(misuse, null))
+        .to.throw('training "options" must be a plain object.')
     })
 
     it('throws if "options" contains an invalid option', () => {
-      expect(_.partial(misuse, {foo: 'bar'})).to.throw()
+      options.a = 'foo'
+      expect(_.partial(misuse, options)).to.throw(
+        `Unknown training option "a", try: ${_.keys(_.without(options, 'a'))}`
+      )
     })
 
     it('throws if "batch" is not a boolean or number', () => {
-      expect(_.partial(misuse, {batch: ''})).to.throw()
+      options.batch = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "batch" must be a boolean or number.')
     })
 
     it('throws if "errorFn" is not a function', () => {
-      expect(_.partial(misuse, {errorFn: ''})).to.throw()
+      options.errorFn = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "errorFn" must be a function.')
     })
 
     it('throws if "errorThreshold" is not a number', () => {
-      expect(_.partial(misuse, {errorThreshold: ''})).to.throw()
+      options.errorThreshold = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "errorThreshold" must be a number.')
     })
 
     it('throws if "frequency" is not a number', () => {
-      expect(_.partial(misuse, {frequency: ''})).to.throw()
+      options.frequency = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "frequency" must be a number.')
     })
 
     it('throws if "maxEpochs" is not a number', () => {
-      expect(_.partial(misuse, {maxEpochs: ''})).to.throw()
+      options.maxEpochs = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "maxEpochs" must be a number')
     })
 
     it('throws if "onFail" is not a function', () => {
-      expect(_.partial(misuse, {onFail: ''})).to.throw()
+      options.onFail = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "onFail" must be a function.')
     })
 
     it('throws if "onProgress" is not a function', () => {
-      expect(_.partial(misuse, {onProgress: ''})).to.throw()
+      options.onProgress = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "onProgress" must be a function.')
     })
 
     it('throws if "onSuccess" is not a function', () => {
-      expect(_.partial(misuse, {onSuccess: ''})).to.throw()
+      options.onSuccess = ''
+      expect(_.partial(misuse, options))
+        .to.throw('training option "onSuccess" must be a function.')
     })
   })
 })


### PR DESCRIPTION
Fixes #91

- [x] split network train method into trainer class, rename `correct()` to `train()`
- [x] split neuron/layer/network train logic into 2 parts at Trainer level:
  - [x] back prop of deltas
  - [x] weight updates
- [x] add trainer batch option (see #91), updating weights at the appropriate time